### PR TITLE
Added Set method to directly set injection values

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -43,6 +43,10 @@ type TypeMapper interface {
 	// This is really only useful for mapping a value as an interface, as interfaces
 	// cannot at this time be referenced directly without a pointer.
 	MapTo(interface{}, interface{}) TypeMapper
+	// Provides a possibility to directly insert a mapping based on type and value.
+	// This makes it possible to directly map type arguments not possible to instantiate
+	// with reflect like unidirectional channels.
+	Set(reflect.Type, reflect.Value) TypeMapper
 	// Returns the Value that is mapped to the current type. Returns a zeroed Value if
 	// the Type has not been mapped.
 	Get(reflect.Type) reflect.Value
@@ -141,6 +145,13 @@ func (i *injector) Map(val interface{}) TypeMapper {
 
 func (i *injector) MapTo(val interface{}, ifacePtr interface{}) TypeMapper {
 	i.values[InterfaceOf(ifacePtr)] = reflect.ValueOf(val)
+	return i
+}
+
+// Maps the given reflect.Type to the given reflect.Value and returns
+// the Typemapper the mapping has been registered in.
+func (i *injector) Set(typ reflect.Type, val reflect.Value) TypeMapper {
+	i.values[typ] = val
 	return i
 }
 


### PR DESCRIPTION
Hey there

This PR provides a Set API to directly set reflection types to reflection values. There are some cases with channels where mapping with Map is not sufficient and mapping with MapTo is not possible because no valid interface can be provided:

If there's two channels of the same type, and we want to map one of them to a receiving channel and the other to a sending channel, currently we'd have to get the interface pointer of a receiving channel and one of a sending channel to be able to pass them to MapTo. But using [reflect.MakeChan](http://golang.org/pkg/reflect/#MakeChan), there's no possibility to instantiate unidirectional channels (which makes sense), so there's no possibility to instantiate that interface.

Also, a Set method makes life easier for those using reflection in their projects.

What do you think?

(the PR will not pass on wercker since the test file has a hardcoded reference to this repo)
