### PR TITLE
Add .MapHandler, which allows mapping types to a handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ type TypeMapper interface {
 	// This is really only useful for mapping a value as an interface, as interfaces
 	// cannot at this time be referenced directly without a pointer.
 	MapTo(interface{}, interface{}) TypeMapper
+	// Maps the outputs types of the function to the handler.
+	// The handler is run whenever the type is requested.
+	MapHandler(interface{}) TypeMapper
 	// Provides a possibility to directly insert a mapping based on type and value.
 	// This makes it possible to directly map type arguments not possible to instantiate
 	// with reflect like unidirectional channels.

--- a/inject_test.go
+++ b/inject_test.go
@@ -157,3 +157,56 @@ func TestInjectImplementors(t *testing.T) {
 
 	expect(t, injector.Get(inject.InterfaceOf((*fmt.Stringer)(nil))).IsValid(), true)
 }
+
+func Test_InjectorMapHandler(t *testing.T) {
+	injector := inject.New()
+
+	timesRun := 0 // Count number of times the handler was run
+
+	handler := func() (string, int) {
+		timesRun++
+		return "some dependency", 11
+	}
+
+	injector.MapHandler(handler)
+
+	expect(t, injector.Get(reflect.TypeOf("string")).IsValid(), true)
+	expect(t, injector.Get(reflect.TypeOf(11)).IsValid(), true)
+	expect(t, injector.Get(reflect.TypeOf(handler)).IsValid(), false) // Handler itself should NOT be mapped
+	expect(t, timesRun, 2)
+}
+
+func Test_InjectorInvokeWithMapHandler(t *testing.T) {
+	injector := inject.New()
+
+	handler := func() (string, int) {
+		return "some dependency", 11
+	}
+
+	injector.MapHandler(handler)
+
+	var (
+		s string
+		i int
+	)
+
+	injector.Invoke(func(j string, k int) {
+		s = j
+		i = k
+	})
+
+	expect(t, s, "some dependency")
+	expect(t, i, 11)
+}
+
+func Test_InjectorCanAcceptFuncs(t *testing.T) {
+	injector := inject.New()
+
+	handler := func() (string, int) {
+		return "some dependency", 11
+	}
+
+	injector.Map(handler)
+
+	expect(t, injector.Get(reflect.TypeOf(handler)).IsValid(), true)
+}


### PR DESCRIPTION
This commit implements the functionality I described in [this](https://github.com/go-martini/martini/issues/322) "issue".  It supports mapping types to handlers, which are executed to return the desired value.  To maintain backwards compatibility, the handler is not run when the type is a function.

This commit is designed to target a specific pattern in martini.  Let's say I have a martini handler that maps a user, and a few web handlers that need a user:

``` go
func setupUser(c martini.Context) {
  var user User
  c.Map(&user)
}

m.Get("/user/me", setupUser, func(u *User) string {
  return u.String()
})

m.Get("/organization", setupUser, func(u *User) string {
  return u.Organization.String()
})
```

With this commit I can do:

``` go
func setupUser(c martini.Context) *User {
  var user User
  c.Map(&user)
  return &user
}

m.MapHandler(setupUser)

m.Get("/user/me", func(u *User) string {
  return u.String()
})

m.Get("/organization", func(u *User) string {
  return u.Organization.String()
})
```

I can request a user from anywhere without having to explicitly call the handler.  Plus, the user is available directly, without the handler, on every subsequent call.
