### PR TITLE
MapTo should ignore nil

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -144,7 +144,9 @@ func (i *injector) Map(val interface{}) TypeMapper {
 }
 
 func (i *injector) MapTo(val interface{}, ifacePtr interface{}) TypeMapper {
-	i.values[InterfaceOf(ifacePtr)] = reflect.ValueOf(val)
+	if !reflect.ValueOf(val).IsNil() {
+		i.values[InterfaceOf(ifacePtr)] = reflect.ValueOf(val)
+	}
 	return i
 }
 


### PR DESCRIPTION
Typically, an interface method is implemented as a placeholder like this 

``` go
func() martini.Handler {
    return func() {

    }
}
```

If MapTo ignore nil input, the injector don't have to care about it anymore.
Then, the above function could be reduced to 

``` go
func() martini.Handler {
 return nil
}
```
