### PR TITLE
Panic on ambiguous implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ type Injector interface {
 	// dependency in its Type map it will check its parent before returning an
 	// error.
 	SetParent(Injector)
+	// SetOptions sets options to configure the injector.
+	SetOptions(InjectorOptions)
 }
 ```
 

--- a/inject.go
+++ b/inject.go
@@ -180,10 +180,8 @@ func (i *injector) Get(t reflect.Type) reflect.Value {
 			}
 		}
 	}
-	if len(impls) > 1 {
-		if i.options.PanicOnAmbiguity {
-			panic(fmt.Sprintf("Expect single matching implementation but found %v", len(impls)))
-		}
+	if len(impls) > 1 && i.options.PanicOnAmbiguity {
+		panic(fmt.Sprintf("Expect single matching implementation but found %v", len(impls)))
 	}
 	if len(impls) > 0 {
 		val = impls[0]

--- a/inject.go
+++ b/inject.go
@@ -183,7 +183,7 @@ func (i *injector) Get(t reflect.Type) reflect.Value {
 		}
 	}
 	if len(impls) > 1 && i.options.PanicOnAmbiguity {
-		panic(fmt.Sprintf("Expect single matching implementation but found %v", len(impls)))
+		panic(fmt.Sprintf("Expected single matching implementation for type <%v> but found %v: %v", t, len(impls), impls))
 	}
 	if len(impls) > 0 {
 		val = impls[0]

--- a/inject.go
+++ b/inject.go
@@ -56,6 +56,8 @@ type TypeMapper interface {
 
 // InjectorOptions contains options to configure the injector
 type InjectorOptions struct {
+	// If PanicOnAmbiguity is set to true, Get method will panic if it finds multiple
+	// implementations that satisfy the given type.
 	PanicOnAmbiguity bool
 }
 

--- a/inject_test.go
+++ b/inject_test.go
@@ -176,7 +176,7 @@ func TestInjectImplementors_AmbiguousImplementation(t *testing.T) {
 func TestInjectImplementors_AmbiguousImplementationPanic(t *testing.T) {
 	defer func() {
 		r := recover()
-		expect(t, r, "Expect single matching implementation but found 2")
+		expect(t, r, "Expected single matching implementation for type <fmt.Stringer> but found 2: [<*inject.Greeter Value> <*inject.Greeter2 Value>]")
 	}()
 
 	injector := New()

--- a/inject_test.go
+++ b/inject_test.go
@@ -11,7 +11,7 @@ type SpecialString interface {
 
 type TestStruct struct {
 	Dep1 string        `inject:"t" json:"-"`
-	Dep2 SpecialString `inject:"t"`
+	Dep2 SpecialString `inject`
 	Dep3 string
 }
 
@@ -185,5 +185,5 @@ func TestInjectImplementors_AmbiguousImplementationPanic(t *testing.T) {
 	})
 	g1, g2 := &Greeter{"Jeremy"}, &Greeter2{"Tom"}
 	injector.Map(g1).Map(g2)
-	expect(t, injector.Get(InterfaceOf((*fmt.Stringer)(nil))).IsValid(), true)
+	injector.Get(InterfaceOf((*fmt.Stringer)(nil)))
 }

--- a/translations/README_zh_cn.md
+++ b/translations/README_zh_cn.md
@@ -35,6 +35,8 @@ type Injector interface {
     // SetParent用来设置父injector. 如果在当前injector的Type map中找不到依赖，
     // 将会继续从它的父injector中找，直到返回error.
     SetParent(Injector)
+    // SetOptions提供一个接口用于设置injector.
+    SetOptions(InjectorOptions)
 }
 ```
 


### PR DESCRIPTION
Currently, if there're multiple implementations that satisfy the given type, the library will pick the first one silently. This PR addresses that by adding an option PanicOnAmbiguity which, if set to true, will make the program panic when there're more than one implementations available. 