### PR TITLE
Use id to identify objects of the same type

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,18 +74,18 @@ Invoker represents an interface for calling functions via reflection.
 ```go
 type TypeMapper interface {
 	// Maps the interface{} value based on its immediate type from reflect.TypeOf.
-	Map(interface{}) TypeMapper
+	Map(string, interface{}) TypeMapper
 	// Maps the interface{} value based on the pointer of an Interface provided.
 	// This is really only useful for mapping a value as an interface, as interfaces
 	// cannot at this time be referenced directly without a pointer.
-	MapTo(interface{}, interface{}) TypeMapper
+	MapTo(string, interface{}, interface{}) TypeMapper
 	// Provides a possibility to directly insert a mapping based on type and value.
 	// This makes it possible to directly map type arguments not possible to instantiate
 	// with reflect like unidirectional channels.
-	Set(reflect.Type, reflect.Value) TypeMapper
+	Set(string, reflect.Type, reflect.Value) TypeMapper
 	// Returns the Value that is mapped to the current type. Returns a zeroed Value if
 	// the Type has not been mapped.
-	Get(reflect.Type) reflect.Value
+	Get(string, reflect.Type) reflect.Value
 }
 ```
 

--- a/inject.go
+++ b/inject.go
@@ -112,6 +112,7 @@ func (inj *injector) Invoke(f interface{}) ([]reflect.Value, error) {
 // that is tagged with 'inject'.
 // Returns an error if the injection fails.
 func (inj *injector) Apply(val interface{}) error {
+	var err error
 	v := reflect.ValueOf(val)
 
 	for v.Kind() == reflect.Ptr {
@@ -132,12 +133,15 @@ func (inj *injector) Apply(val interface{}) error {
 			ft := f.Type()
 			v := inj.Get(id, ft)
 			if !v.IsValid() {
-				return fmt.Errorf("Value not found for type %v", ft)
+				err = fmt.Errorf("Value not found for type %v", ft)
+				continue
 			}
-
 			f.Set(v)
 		}
+	}
 
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The current way has 2 disadvantages:
1. If there are 2 objects of the same type to be mapped into injector, the former one will be overwritten by the latter one.
2. the tag format `inject` is not encouraged by `go tool vet`. A tag should have a value, which i think an ID would be an appropriate choice.