### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -102,7 +102,7 @@ func (inj *injector) Invoke(f interface{}) ([]reflect.Value, error) {
 	return reflect.ValueOf(f).Call(in), nil
 }
 
-// Maps dependencies in the Type map to each field in the struct
+// Apply: Maps dependencies in the Type map to each field in the struct
 // that is tagged with 'inject'.
 // Returns an error if the injection fails.
 func (inj *injector) Apply(val interface{}) error {
@@ -136,7 +136,7 @@ func (inj *injector) Apply(val interface{}) error {
 	return nil
 }
 
-// Maps the concrete value of val to its dynamic type using reflect.TypeOf,
+// Map: Maps the concrete value of val to its dynamic type using reflect.TypeOf,
 // It returns the TypeMapper registered in.
 func (i *injector) Map(val interface{}) TypeMapper {
 	i.values[reflect.TypeOf(val)] = reflect.ValueOf(val)
@@ -148,7 +148,7 @@ func (i *injector) MapTo(val interface{}, ifacePtr interface{}) TypeMapper {
 	return i
 }
 
-// Maps the given reflect.Type to the given reflect.Value and returns
+// Set: Maps the given reflect.Type to the given reflect.Value and returns
 // the Typemapper the mapping has been registered in.
 func (i *injector) Set(typ reflect.Type, val reflect.Value) TypeMapper {
 	i.values[typ] = val


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say "opt out" to opt out of future CodeLingo outreach PRs.*